### PR TITLE
Prevent dynamic restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,13 @@ traefik_binary_url: https://github.com/containous/traefik/releases/download/v1.7
 traefik_tmp_path: "/tmp"
 traefik_bin_path: "{{ traefik_install_dir }}/traefik"
 traefik_config_file: /etc/traefik.toml
+# example variables for dynamic configs templates w/traefik version 2.x.x
+# traefik_dynamic_configs:
+#   - src: traefik-dynamic.toml
+#     dest: /etc/traefik-dynamic.toml
+# restart traefik on dynamic config changes
+# set this to false if using traefiks watch feature on those files
+traefik_dynamic_config_restart: true
 traefik_template: traefik.toml
 traefik_systemd_unit_template: traefik.service
 traefik_systemd_unit_dest: /etc/systemd/system/traefik.service

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-# defaults file for kibatic.traefik
 traefik_install_dir: /usr/bin
 traefik_binary_url: https://github.com/containous/traefik/releases/download/v1.7.6/traefik_linux-amd64
 # example binary release url for traefik v2.x.x
@@ -12,6 +11,9 @@ traefik_config_file: /etc/traefik.toml
 # traefik_dynamic_configs:
 #   - src: traefik-dynamic.toml
 #     dest: /etc/traefik-dynamic.toml
+# restart traefik on dynamic config changes
+# set this to false if using traefiks watch feature on those files
+traefik_dynamic_config_restart: true
 traefik_systemd_unit_template: traefik.service
 traefik_systemd_unit_dest: /etc/systemd/system/traefik.service
 traefik_update: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,8 +35,7 @@
     owner: root
     group: root
     mode: 0644
-  notify:
-    - Restart traefik
+  notify: "{{ traefik_dynamic_config_restart | ternary(['Restart traefik'], []) }}"
   with_items: "{{ traefik_dynamic_configs | list }}"
   when: traefik_dynamic_configs is defined
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,7 @@
     dest: "{{ traefik_config_file }}"
     owner: root
     group: root
-    mode: 0744
+    mode: 0644
   notify:
     - Restart traefik
 
@@ -34,7 +34,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0744
+    mode: 0644
   notify:
     - Restart traefik
   with_items: "{{ traefik_dynamic_configs | list }}"


### PR DESCRIPTION
Traefik is able to handle dynamic config updates itself
when `watch` is set to `true`.