### PR TITLE
Allow locking down traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ traefik_config_file: /etc/traefik.toml
 traefik_template: traefik.toml
 traefik_systemd_unit_template: traefik.service
 traefik_systemd_unit_dest: /etc/systemd/system/traefik.service
+# restrict traefik permissions to minimum
+traefik_systemd_lockdown: false
+# additional paths that are accessed by traeifk read-only, e.g. /etc/ssl/traefik.pem, /etc/ssl/traefik.crt
+traefik_systemd_ro_paths: []
+# additional paths that are accessed by traeifk read-write, e.g. /etc/traefik-acme.json, /var/log/traefik/access.log
+traefik_systemd_rw_paths: []
 traefik_update: false
 traefik_manage_service: true
 traefik_service_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,12 @@ traefik_config_file: /etc/traefik.toml
 #     dest: /etc/traefik-dynamic.toml
 traefik_systemd_unit_template: traefik.service
 traefik_systemd_unit_dest: /etc/systemd/system/traefik.service
+# restrict traefik permissions to minimum
+traefik_systemd_lockdown: false
+# additional paths that are accessed by traeifk read-only, e.g. /etc/ssl/traefik.pem, /etc/ssl/traefik.crt
+traefik_systemd_ro_paths: []
+# additional paths that are accessed by traeifk read-write, e.g. /etc/traefik-acme.json, /var/log/traefik/access.log
+traefik_systemd_rw_paths: []
 traefik_update: false
 traefik_manage_service: true
 traefik_service_enabled: true

--- a/templates/traefik.service.j2
+++ b/templates/traefik.service.j2
@@ -2,11 +2,44 @@
 # @see https://raw.githubusercontent.com/containous/traefik/master/contrib/systemd/traefik.service
 [Unit]
 Description=Traefik
+Documentation=https://docs.traefik.io
+After=network-online.target
+AssertFileIsExecutable={{ traefik_bin_path }}
+AssertPathExists={{ traefik_config_file }}
+{% for path in traefik_dynamic_configs | default([]) | map(attribute='dest') %}
+AssertPathExists={{ path }}
+{% endfor %}
 
 [Service]
 Type=notify
 ExecStart={{ traefik_bin_path }} --configFile={{ traefik_config_file }}
 Restart=on-failure
+WatchdogSec=1s
+
+{% if traefik_systemd_lockdown %}
+# lock down system access
+# prohibit any operating system and configuration modification
+ProtectSystem=strict
+# create separate, new (and empty) /tmp and /var/tmp filesystems
+PrivateTmp=true
+# make /home directories inaccessible
+ProtectHome=true
+# turns off access to physical devices (/dev/...)
+PrivateDevices=true
+# make kernel settings (procfs and sysfs) read-only
+ProtectKernelTunables=true
+# make cgroups /sys/fs/cgroup read-only
+ProtectControlGroups=true
+# limit file system access
+{% if traefik_systemd_rw_paths %}
+ReadWritePaths={{ traefik_systemd_rw_paths | join(',') }}
+{% endif %}
+ReadOnlyPaths={{ ([traefik_config_file] + (traefik_dynamic_configs | default([]) | map(attribute='dest') | list) + traefik_systemd_ro_paths) | join(',') }}
+# limit number of processes in this unit
+LimitNPROC=1
+# Limit the number of file descriptors
+LimitNOFILE=1048576
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
It's a internet facing service running as root.
This change allows restricting access to minimal set of files.

The PR might collide with #4. Please give me a note, if I should rebase it on top of the other one.