### PR TITLE
Ensure log dir is created before starting traefik the first time

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -90,6 +90,14 @@
     dest: "{{ traefik_logrotate_config_path }}"
   when: traefik_log_rotation
 
+- name: Ensure log dir
+  file:
+    path: "{{ traefik_log_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+
 - name: Ensure traefik service is enabled and running
   systemd:
     name: traefik


### PR DESCRIPTION
Current implementation breaks on centos8 with more strict settings of
systemd