### PR TITLE
Refactoring

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,18 +65,24 @@
   when: traefik_binary_url.endswith(".tar.gz")
 
 - name: Download & Expand Tarred Traefik binary
+  become: False
   unarchive:
     src: "{{ traefik_binary_url }}"
     creates: "{{ traefik_tmp_path }}/traefik"
     remote_src: true
     dest: "{{ traefik_tmp_path }}"
     force: "{{ traefik_update }}"
+  register: _download_binary
+  until: _download_binary is succeeded
+  retries: 5
+  delay: 2
+  delegate_to: localhost
+  check_mode: false
   when: traefik_binary_url.endswith(".tar.gz")
 
 - name: Copy Expanded Traefik binary only to bin path
   copy:
     src: "{{ traefik_tmp_path }}/traefik"
-    remote_src: true
     dest: "{{ traefik_bin_path }}"
     owner: root
     group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 # tasks file for kibatic.traefik
 ---
-- name: Create traefik systemd unit
+- name: Create Traefik systemd unit
   template:
     src: "{{ traefik_systemd_unit_template }}.j2"
     dest: "{{ traefik_systemd_unit_dest }}"
@@ -18,7 +18,7 @@
   with_items:
     - "{{ traefik_install_dir }}"
 
-- name: Copy traefik config file
+- name: Copy Traefik config file
   template:
     src: "{{ traefik_template }}.j2"
     dest: "{{ traefik_config_file }}"
@@ -28,26 +28,19 @@
   notify:
     - Restart traefik
 
-- name: Copy traefik dynamic config files (if traevik v2.x.x & file provider)
+- name: Copy Traefik dynamic config files (if Traefik v2.x.x & file provider)
   template:
     src: "{{ item.src }}.j2"
     dest: "{{ item.dest }}"
     owner: root
     group: root
     mode: 0744
-  notify:
-    - Restart traefik
   with_items: "{{ traefik_dynamic_configs | list }}"
   when: traefik_dynamic_configs is defined
+  notify:
+    - Restart traefik
 
-- name: Ensure traefik service is stopped before traefik update
-  service:
-    name: traefik
-    state: stopped
-    enabled: true
-  when: traefik_update
-
-- name: Download Untarred Traefik binary
+- name: Download untarred Traefik binary to bin path
   get_url:
     url: "{{ traefik_binary_url }}"
     dest: "{{ traefik_bin_path }}"
@@ -56,7 +49,8 @@
     mode: 0755
     force: "{{ traefik_update }}"
   when: not traefik_binary_url.endswith(".tar.gz")
-
+  notify:
+    - Restart traefik
 
 - name: Ensure tmp directory
   file:
@@ -64,23 +58,24 @@
     state: directory
   when: traefik_binary_url.endswith(".tar.gz")
 
-- name: Download & Expand Tarred Traefik binary
+- name: Download tarball & extract Traefik binary
   become: False
   unarchive:
     src: "{{ traefik_binary_url }}"
-    creates: "{{ traefik_tmp_path }}/traefik"
     remote_src: true
     dest: "{{ traefik_tmp_path }}"
-    force: "{{ traefik_update }}"
+    extra_opts:
+      - 'traefik'
   register: _download_binary
   until: _download_binary is succeeded
   retries: 5
   delay: 2
   delegate_to: localhost
+  run_once: true
   check_mode: false
   when: traefik_binary_url.endswith(".tar.gz")
 
-- name: Copy Expanded Traefik binary only to bin path
+- name: Copy extracted Traefik binary to bin path
   copy:
     src: "{{ traefik_tmp_path }}/traefik"
     dest: "{{ traefik_bin_path }}"
@@ -89,6 +84,8 @@
     mode: 0755
     force: "{{ traefik_update }}"
   when: traefik_binary_url.endswith(".tar.gz")
+  notify:
+    - Restart traefik
 
 - name: Setup log rotation if needed
   template:
@@ -96,7 +93,7 @@
     dest: "{{ traefik_logrotate_config_path }}"
   when: traefik_log_rotation
 
-- name: Ensure traefik service is enabled and running
+- name: Ensure Traefik service is enabled and running
   systemd:
     name: traefik
     state: "{{ traefik_service_state }}"


### PR DESCRIPTION
Multiple changes: 
- removed force option from unarchive task (force is not supported anymore from ansible 2.10)
- removed unarchive creates option which prevents updating (the newer archive is not unarchived if the file specified in creates exist)
- replaced creates by extra-args option which specifies the file which we want to unarchive
- replaced traefik service stop&start when updating by handlers
- fixed typos